### PR TITLE
Update app.js to work on global install

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,11 @@
+#!/usr/bin/env node
+
 var chokidar = require('chokidar')
   , sass = require('node-sass')
   , fs = require('fs')
   , path = require('path')
-  , inputDir = path.join(process.cwd(), process.argv[1])
-  , outputDir = path.join(process.cwd(), process.argv[2])
+  , inputDir = path.join(process.cwd(), process.argv[2])
+  , outputDir = path.join(process.cwd(), process.argv[3])
   , watcher = chokidar.watch(inputDir, {persistent: true});
 
 console.log("Input: " + inputDir, "Output: " + outputDir)


### PR DESCRIPTION
This will remove the "(" error, but does not get it fully working

Will run after global install
Changed args to 2 and 3 from 1 and 2
argv = [node, /user/bin/sass-watch, inputdir, outputdir]
